### PR TITLE
feat(dropbox): add Dropbox as a second recipe-storage backend

### DIFF
--- a/extractor/src/intTest/java/net/shamansoft/cookbook/service/StorageServiceIntegrationTest.java
+++ b/extractor/src/intTest/java/net/shamansoft/cookbook/service/StorageServiceIntegrationTest.java
@@ -81,7 +81,12 @@ class StorageServiceIntegrationTest {
         when(googleDrive.createFolder(eq(FOLDER_NAME), eq(ACCESS_TOKEN)))
                 .thenReturn(folderItem);
 
-        storageService = new StorageService(firestore, tokenEncryptionService, googleAuthClient, googleDrive);
+        net.shamansoft.cookbook.client.DropboxAuthClient dropboxAuthClient =
+                mock(net.shamansoft.cookbook.client.DropboxAuthClient.class);
+        net.shamansoft.cookbook.service.DropboxStorageProvider dropboxStorageProvider =
+                mock(net.shamansoft.cookbook.service.DropboxStorageProvider.class);
+        storageService = new StorageService(firestore, tokenEncryptionService, googleAuthClient, googleDrive,
+                dropboxAuthClient, dropboxStorageProvider);
 
         // Set required @Value fields using reflection
         ReflectionTestUtils.setField(storageService, "defaultFolderName", FOLDER_NAME);

--- a/extractor/src/main/java/net/shamansoft/cookbook/client/DropboxAuthClient.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/client/DropboxAuthClient.java
@@ -1,0 +1,151 @@
+package net.shamansoft.cookbook.client;
+
+import com.google.cloud.Timestamp;
+import lombok.extern.slf4j.Slf4j;
+import net.shamansoft.cookbook.exception.DatabaseUnavailableException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+/**
+ * Client for Dropbox OAuth2 (authorization-code + offline refresh token).
+ * Mirrors {@link GoogleAuthClient}. Non-PKCE: the app secret is held server-side.
+ */
+@Service
+@Slf4j
+public class DropboxAuthClient {
+
+    private static final long TOKEN_BUFFER_SECONDS = 300;
+    private static final String TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
+    private static final String REVOKE_URL = "https://api.dropboxapi.com/2/auth/token/revoke";
+    private static final int DEFAULT_EXPIRES_IN = 14400;
+
+    private final RestClient restClient;
+
+    @Value("${cookbook.dropbox.app-key:REPLACE_WITH_DROPBOX_APP_KEY}")
+    private String appKey;
+    @Value("${cookbook.dropbox.app-secret:REPLACE_WITH_DROPBOX_APP_SECRET}")
+    private String appSecret;
+
+    public DropboxAuthClient(@Qualifier("genericRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public TokenResponse exchangeAuthorizationCode(String authorizationCode, String redirectUri) {
+        log.info("Exchanging Dropbox authorization code for tokens, redirect_uri: {}", redirectUri);
+        try {
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("code", authorizationCode);
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", appKey);
+            params.add("client_secret", appSecret);
+            params.add("redirect_uri", redirectUri);
+
+            Map<String, Object> response = restClient.post()
+                    .uri(TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                    });
+
+            if (response == null || !response.containsKey("access_token")) {
+                throw new IllegalArgumentException("Invalid response from Dropbox OAuth: " + response);
+            }
+            String accessToken = (String) response.get("access_token");
+            String refreshToken = (String) response.get("refresh_token");
+            Integer expiresIn = (Integer) response.get("expires_in");
+            if (refreshToken == null) {
+                throw new IllegalStateException(
+                        "No refresh token received. Ensure token_access_type=offline in the authorize URL.");
+            }
+            if (expiresIn == null) {
+                expiresIn = DEFAULT_EXPIRES_IN;
+            }
+            log.info("Exchanged Dropbox authorization code, expires in {}s", expiresIn);
+            return new TokenResponse(accessToken, refreshToken, expiresIn.longValue());
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw e;
+        } catch (org.springframework.web.client.RestClientResponseException e) {
+            log.error("Dropbox token exchange failed with status {}: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IllegalArgumentException(
+                    "Dropbox OAuth token exchange failed: " + e.getResponseBodyAsString()
+                            + ". Check that app-key, app-secret, and redirect_uri match your Dropbox app configuration.");
+        } catch (Exception e) {
+            log.error("Failed to exchange Dropbox authorization code: {}", e.getMessage(), e);
+            throw new DatabaseUnavailableException("Dropbox OAuth token exchange failed: " + e.getMessage(), e);
+        }
+    }
+
+    public RefreshTokenResponse refreshAccessToken(String refreshToken) {
+        log.info("Refreshing Dropbox access token");
+        try {
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "refresh_token");
+            params.add("refresh_token", refreshToken);
+            params.add("client_id", appKey);
+            params.add("client_secret", appSecret);
+
+            Map<String, Object> response = restClient.post()
+                    .uri(TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                    });
+
+            if (response == null || !response.containsKey("access_token")) {
+                throw new RuntimeException("Invalid response from Dropbox OAuth: " + response);
+            }
+            String newAccessToken = (String) response.get("access_token");
+            Integer expiresIn = (Integer) response.get("expires_in");
+            if (expiresIn == null) {
+                expiresIn = DEFAULT_EXPIRES_IN;
+            }
+            Timestamp newExpiresAt = Timestamp.ofTimeSecondsAndNanos(
+                    System.currentTimeMillis() / 1000 + expiresIn, 0);
+            log.info("Refreshed Dropbox token, expires in {}s", expiresIn);
+            return new RefreshTokenResponse(newAccessToken, newExpiresAt);
+        } catch (Exception e) {
+            log.error("Failed to refresh Dropbox token: {}", e.getMessage(), e);
+            throw new DatabaseUnavailableException("Failed to refresh Dropbox token: " + e.getMessage(), e);
+        }
+    }
+
+    public boolean isTokenExpired(Timestamp expiresAt) {
+        if (expiresAt == null) {
+            return true;
+        }
+        long now = System.currentTimeMillis() / 1000;
+        return (expiresAt.getSeconds() - now) <= TOKEN_BUFFER_SECONDS;
+    }
+
+    /**
+     * Best-effort server-side token revocation. Never throws.
+     */
+    public void revokeToken(String accessToken) {
+        try {
+            restClient.post()
+                    .uri(REVOKE_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .toBodilessEntity();
+            log.info("Revoked Dropbox token");
+        } catch (Exception e) {
+            log.warn("Dropbox token revoke failed (ignored): {}", e.getMessage());
+        }
+    }
+
+    public record TokenResponse(String accessToken, String refreshToken, long expiresIn) {
+    }
+
+    public record RefreshTokenResponse(String accessToken, Timestamp expiresAt) {
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/client/DropboxClient.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/client/DropboxClient.java
@@ -1,0 +1,152 @@
+package net.shamansoft.cookbook.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HTTP client for the Dropbox file API (App-folder access).
+ * All {@code path} arguments are relative to the app folder; {@code ""} is the app-folder root.
+ */
+@Slf4j
+@Service
+public class DropboxClient {
+
+    private static final String API = "https://api.dropboxapi.com";
+    private static final String CONTENT = "https://content.dropboxapi.com";
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public DropboxClient(@Qualifier("genericRestClient") RestClient restClient, ObjectMapper objectMapper) {
+        this.restClient = restClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Create a folder; a 409 path/conflict is treated as "already exists". */
+    public void createFolder(String path, String token) {
+        try {
+            rpc(API + "/2/files/create_folder_v2", Map.of("path", path, "autorename", false), token);
+            log.info("Created Dropbox folder: {}", path);
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().value() == 409) {
+                log.info("Dropbox folder already exists: {}", path);
+                return;
+            }
+            throw new ClientException("Failed to create Dropbox folder: " + path, e);
+        }
+    }
+
+    public FileEntry upload(String path, byte[] content, String token) {
+        String arg = writeArg(Map.of("path", path, "mode", "overwrite", "mute", true));
+        Map<String, Object> resp = restClient.post()
+                .uri(CONTENT + "/2/files/upload")
+                .header("Authorization", "Bearer " + token)
+                .header("Dropbox-API-Arg", arg)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(content)
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                });
+        if (resp == null || resp.get("id") == null) {
+            throw new ClientException("Dropbox upload returned no id for path: " + path);
+        }
+        return toFileEntry(resp);
+    }
+
+    public byte[] downloadAsBytes(String path, String token) {
+        String arg = writeArg(Map.of("path", path));
+        byte[] bytes = restClient.post()
+                .uri(CONTENT + "/2/files/download")
+                .header("Authorization", "Bearer " + token)
+                .header("Dropbox-API-Arg", arg)
+                .retrieve()
+                .body(byte[].class);
+        if (bytes == null) {
+            throw new ClientException("Dropbox download returned no content for path: " + path);
+        }
+        return bytes;
+    }
+
+    public String downloadAsString(String path, String token) {
+        return new String(downloadAsBytes(path, token), StandardCharsets.UTF_8);
+    }
+
+    public FileEntry getMetadata(String path, String token) {
+        Map<String, Object> resp = rpc(API + "/2/files/get_metadata", Map.of("path", path), token);
+        if (resp == null || resp.get("id") == null) {
+            throw new ClientException("Dropbox get_metadata returned no id for path: " + path);
+        }
+        return toFileEntry(resp);
+    }
+
+    public ListResult listFolder(String path, int limit, String token) {
+        return parseList(rpc(API + "/2/files/list_folder", Map.of("path", path, "limit", limit), token));
+    }
+
+    public ListResult listFolderContinue(String cursor, String token) {
+        return parseList(rpc(API + "/2/files/list_folder/continue", Map.of("cursor", cursor), token));
+    }
+
+    private Map<String, Object> rpc(String uri, Map<String, Object> body, String token) {
+        return restClient.post()
+                .uri(uri)
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private ListResult parseList(Map<String, Object> resp) {
+        if (resp == null) {
+            throw new ClientException("Dropbox list_folder returned null");
+        }
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) resp.get("entries");
+        List<FileEntry> files = new ArrayList<>();
+        if (entries != null) {
+            for (Map<String, Object> e : entries) {
+                if ("file".equals(e.get(".tag"))) {
+                    files.add(toFileEntry(e));
+                }
+            }
+        }
+        String cursor = (String) resp.get("cursor");
+        boolean hasMore = Boolean.TRUE.equals(resp.get("has_more"));
+        return new ListResult(files, cursor, hasMore);
+    }
+
+    private static FileEntry toFileEntry(Map<String, Object> e) {
+        return new FileEntry(
+                (String) e.get("id"),
+                (String) e.get("name"),
+                (String) e.get("path_display"),
+                (String) e.get("server_modified"));
+    }
+
+    private String writeArg(Map<String, Object> arg) {
+        try {
+            return objectMapper.writeValueAsString(arg);
+        } catch (Exception e) {
+            throw new ClientException("Failed to build Dropbox-API-Arg header", e);
+        }
+    }
+
+    public record FileEntry(String id, String name, String pathDisplay, String serverModified) {
+    }
+
+    public record ListResult(List<FileEntry> files, String cursor, boolean hasMore) {
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/controller/StorageController.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/controller/StorageController.java
@@ -94,6 +94,72 @@ public class StorageController {
     }
 
     /**
+     * Connect Dropbox storage for the authenticated user.
+     * Mirrors the Google Drive connect flow; provider selection is server-side.
+     */
+    @PostMapping("/dropbox/connect")
+    public ResponseEntity<StorageConnectionResponse> connectDropbox(
+            @RequestAttribute("userId") String userId,
+            @RequestBody @Valid StorageConnectionRequest request) {
+
+        log.info("Connecting Dropbox storage for user: {}", userId);
+        try {
+            StorageService.FolderInfo folderInfo = storageService.connectDropbox(
+                    userId,
+                    request.getAuthorizationCode(),
+                    request.getRedirectUri(),
+                    request.getFolderName());
+
+            return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .body(StorageConnectionResponse.success(
+                            "Dropbox connected successfully",
+                            true,
+                            folderInfo.folderId(),
+                            folderInfo.folderName()));
+
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid Dropbox authorization code for user {}: {}", userId, e.getMessage(), e);
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(StorageConnectionResponse.error("Invalid authorization code: " + e.getMessage()));
+        } catch (IllegalStateException e) {
+            log.error("Dropbox OAuth configuration error for user {}: {}", userId, e.getMessage(), e);
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(StorageConnectionResponse.error("OAuth error: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Provider-neutral status: returns whichever provider is currently connected.
+     */
+    @GetMapping("/status")
+    public ResponseEntity<StorageStatusResponse> getStatus(
+            @RequestAttribute("userId") String userId) {
+        log.debug("Getting storage status for user: {}", userId);
+        try {
+            StorageInfo info = storageService.getStorageInfo(userId);
+            return ResponseEntity.ok(StorageStatusResponse.fromStorageInfo(info));
+        } catch (StorageNotConnectedException e) {
+            log.debug("Storage not connected for user: {}", userId);
+            return ResponseEntity.ok(StorageStatusResponse.notConnected());
+        }
+    }
+
+    /**
+     * Provider-neutral disconnect: clears whichever provider is connected.
+     */
+    @DeleteMapping("/disconnect")
+    public ResponseEntity<StorageConnectionResponse> disconnect(
+            @RequestAttribute("userId") String userId) {
+        log.info("Disconnecting storage for user: {}", userId);
+        storageService.disconnectStorage(userId);
+        return ResponseEntity.ok(
+                StorageConnectionResponse.success("Storage disconnected successfully", false));
+    }
+
+    /**
      * Disconnect Google Drive storage for the authenticated user.
      * Removes all stored tokens and configuration.
      *

--- a/extractor/src/main/java/net/shamansoft/cookbook/repository/firestore/model/StorageEntity.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/repository/firestore/model/StorageEntity.java
@@ -27,7 +27,7 @@ public record StorageEntity(String type,
 
     public Map<String, Object> toMap() {
         Map<String, Object> storage = new HashMap<>();
-        storage.put("type", StorageType.GOOGLE_DRIVE.getFirestoreValue());
+        storage.put("type", type != null ? type : StorageType.GOOGLE_DRIVE.getFirestoreValue());
         storage.put("connected", connected);
         storage.put("accessToken", accessToken);
         if (refreshToken != null) {

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/DropboxStorageProvider.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/DropboxStorageProvider.java
@@ -1,0 +1,145 @@
+package net.shamansoft.cookbook.service;
+
+import lombok.extern.slf4j.Slf4j;
+import net.shamansoft.cookbook.client.DropboxClient;
+import net.shamansoft.cookbook.client.GoogleDrive;
+import net.shamansoft.cookbook.dto.StorageType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * {@link StorageProvider} backed by Dropbox (App-folder access). Paths are relative to the
+ * app folder; {@code ""} is the app-folder root. Recipe/media files are addressed by Dropbox id.
+ */
+@Slf4j
+@Service
+public class DropboxStorageProvider implements StorageProvider {
+
+    private final DropboxClient dropboxClient;
+    private final Transliterator transliterator;
+
+    @Value("${cookbook.dropbox.folder-name:}")
+    private String folderName;
+
+    public DropboxStorageProvider(DropboxClient dropboxClient, Transliterator transliterator) {
+        this.dropboxClient = dropboxClient;
+        this.transliterator = transliterator;
+    }
+
+    @Override
+    public StorageType type() {
+        return StorageType.DROPBOX;
+    }
+
+    @Override
+    public String generateFileName(String title) {
+        String lowerAscii = transliterator.toAsciiKebab(title);
+        String base = lowerAscii == null || lowerAscii.isEmpty()
+                ? "recipe-" + System.currentTimeMillis()
+                : lowerAscii;
+        return base + ".yaml";
+    }
+
+    @Override
+    public FolderRef getOrCreateFolder(String accessToken, String folderName) {
+        String sub = normalizeSubfolder(folderName);
+        if (sub.isEmpty()) {
+            // App-folder root: nothing to create (Dropbox provisions the app folder on first write).
+            return new FolderRef("", folderName == null ? "" : folderName.trim());
+        }
+        dropboxClient.createFolder(sub, accessToken);
+        return new FolderRef(sub, folderName.trim());
+    }
+
+    @Override
+    public DriveService.UploadResult uploadRecipeYaml(String accessToken, String folderId, String fileName, String content) {
+        String path = joinPath(folderId, fileName);
+        DropboxClient.FileEntry entry =
+                dropboxClient.upload(path, content.getBytes(StandardCharsets.UTF_8), accessToken);
+        String url = entry.pathDisplay() != null ? entry.pathDisplay() : path;
+        return new DriveService.UploadResult(entry.id(), url);
+    }
+
+    @Override
+    public GoogleDrive.DriveFileListResult listRecipeFiles(String accessToken, String folderId, int pageSize, String pageToken) {
+        DropboxClient.ListResult result = (pageToken == null)
+                ? dropboxClient.listFolder(rootPath(folderId), pageSize, accessToken)
+                : dropboxClient.listFolderContinue(pageToken, accessToken);
+
+        List<GoogleDrive.DriveFileInfo> files = result.files().stream()
+                .filter(f -> f.name() != null && f.name().endsWith(".yaml"))
+                .map(f -> new GoogleDrive.DriveFileInfo(f.id(), f.name(), f.serverModified()))
+                .toList();
+
+        String nextPageToken = result.hasMore() ? result.cursor() : null;
+        return new GoogleDrive.DriveFileListResult(files, nextPageToken);
+    }
+
+    @Override
+    public String getFileContent(String accessToken, String fileId) {
+        return dropboxClient.downloadAsString(fileId, accessToken);
+    }
+
+    @Override
+    public byte[] downloadFile(String accessToken, String fileId) {
+        return dropboxClient.downloadAsBytes(fileId, accessToken);
+    }
+
+    @Override
+    public String getFileMimeType(String accessToken, String fileId) {
+        return mimeTypeForName(dropboxClient.getMetadata(fileId, accessToken).name());
+    }
+
+    @Override
+    public GoogleDrive.DriveFileMetadata getFileMetadata(String accessToken, String fileId) {
+        DropboxClient.FileEntry e = dropboxClient.getMetadata(fileId, accessToken);
+        return new GoogleDrive.DriveFileMetadata(e.id(), e.name(), mimeTypeForName(e.name()), e.serverModified());
+    }
+
+    /** App-folder root is "" (also accept "/"); a stored subfolder path is returned as-is. */
+    static String rootPath(String folderId) {
+        return (folderId == null || folderId.isBlank() || "/".equals(folderId)) ? "" : folderId;
+    }
+
+    static String joinPath(String folderId, String fileName) {
+        String root = rootPath(folderId);
+        return root.isEmpty() ? "/" + fileName : root + "/" + fileName;
+    }
+
+    static String normalizeSubfolder(String folderName) {
+        if (folderName == null || folderName.isBlank()) {
+            return "";
+        }
+        String n = folderName.trim();
+        return n.startsWith("/") ? n : "/" + n;
+    }
+
+    static String mimeTypeForName(String name) {
+        if (name == null) {
+            return "application/octet-stream";
+        }
+        String lower = name.toLowerCase();
+        if (lower.endsWith(".yaml") || lower.endsWith(".yml")) {
+            return "application/x-yaml";
+        }
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+            return "image/jpeg";
+        }
+        if (lower.endsWith(".png")) {
+            return "image/png";
+        }
+        if (lower.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (lower.endsWith(".webp")) {
+            return "image/webp";
+        }
+        if (lower.endsWith(".pdf")) {
+            return "application/pdf";
+        }
+        return "application/octet-stream";
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/GoogleDriveStorageProvider.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/GoogleDriveStorageProvider.java
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class GoogleDriveStorageProvider implements StorageProvider {
 
-    private final GoogleDriveService googleDriveService;
+    private final DriveService googleDriveService;
 
     @Value("${cookbook.drive.folder-name}")
     private String folderName;
 
-    public GoogleDriveStorageProvider(GoogleDriveService googleDriveService) {
+    public GoogleDriveStorageProvider(DriveService googleDriveService) {
         this.googleDriveService = googleDriveService;
     }
 

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/GoogleDriveStorageProvider.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/GoogleDriveStorageProvider.java
@@ -1,0 +1,69 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.client.GoogleDrive;
+import net.shamansoft.cookbook.dto.StorageType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * {@link StorageProvider} backed by Google Drive. Delegates all file operations to the
+ * existing {@link GoogleDriveService} bean (single source of truth for Drive logic).
+ */
+@Service
+public class GoogleDriveStorageProvider implements StorageProvider {
+
+    private final GoogleDriveService googleDriveService;
+
+    @Value("${cookbook.drive.folder-name}")
+    private String folderName;
+
+    public GoogleDriveStorageProvider(GoogleDriveService googleDriveService) {
+        this.googleDriveService = googleDriveService;
+    }
+
+    @Override
+    public StorageType type() {
+        return StorageType.GOOGLE_DRIVE;
+    }
+
+    @Override
+    public String generateFileName(String title) {
+        return googleDriveService.generateFileName(title);
+    }
+
+    @Override
+    public FolderRef getOrCreateFolder(String accessToken, String folderName) {
+        String id = googleDriveService.getOrCreateFolder(accessToken);
+        return new FolderRef(id, this.folderName);
+    }
+
+    @Override
+    public DriveService.UploadResult uploadRecipeYaml(String accessToken, String folderId, String fileName, String content) {
+        return googleDriveService.uploadRecipeYaml(accessToken, folderId, fileName, content);
+    }
+
+    @Override
+    public GoogleDrive.DriveFileListResult listRecipeFiles(String accessToken, String folderId, int pageSize, String pageToken) {
+        return googleDriveService.listRecipeFiles(accessToken, folderId, pageSize, pageToken);
+    }
+
+    @Override
+    public String getFileContent(String accessToken, String fileId) {
+        return googleDriveService.getFileContent(accessToken, fileId);
+    }
+
+    @Override
+    public byte[] downloadFile(String accessToken, String fileId) {
+        return googleDriveService.downloadFile(accessToken, fileId);
+    }
+
+    @Override
+    public String getFileMimeType(String accessToken, String fileId) {
+        return googleDriveService.getFileMimeType(accessToken, fileId);
+    }
+
+    @Override
+    public GoogleDrive.DriveFileMetadata getFileMetadata(String accessToken, String fileId) {
+        return googleDriveService.getFileMetadata(accessToken, fileId);
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/RecipeMediaProxyService.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/RecipeMediaProxyService.java
@@ -3,48 +3,30 @@ package net.shamansoft.cookbook.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.shamansoft.cookbook.dto.StorageInfo;
-import net.shamansoft.cookbook.dto.StorageType;
 import net.shamansoft.cookbook.exception.RecipeNotFoundException;
 import org.springframework.stereotype.Service;
 
 /**
- * Service for proxying media files from Google Drive.
- * Validates user session and fetches media using user's OAuth token.
+ * Proxies media files from the user's connected storage provider.
+ * Validates the user session and uses their access token to fetch the file.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RecipeMediaProxyService {
-    private final DriveService googleDriveService;
+
+    private final StorageProviderResolver storageProviderResolver;
     private final StorageService storageService;
 
-    /**
-     * Get media file from Google Drive.
-     * Validates user session and uses their OAuth token to fetch the file.
-     *
-     * @param userId      Firebase user ID
-     * @param driveFileId Google Drive file ID
-     * @return MediaContent with file data and MIME type
-     * @throws net.shamansoft.cookbook.exception.StorageNotConnectedException if storage not connected
-     * @throws RecipeNotFoundException                                        if file not found
-     */
     public MediaContent getMediaFile(String userId, String driveFileId) {
         log.info("Proxying media file: {} for user: {}", driveFileId, userId);
 
-        // Get user's OAuth token (validates storage connected)
         StorageInfo storage = storageService.getStorageInfo(userId);
-
-        if (storage.type() != StorageType.GOOGLE_DRIVE) {
-            throw new IllegalStateException("Expected Google Drive storage, got: " + storage.type());
-        }
+        StorageProvider provider = storageProviderResolver.resolve(storage.type());
 
         try {
-            // Fetch file from Drive using user's token
-            byte[] content = googleDriveService.downloadFile(
-                    storage.accessToken(), driveFileId);
-
-            String mimeType = googleDriveService.getFileMimeType(
-                    storage.accessToken(), driveFileId);
+            byte[] content = provider.downloadFile(storage.accessToken(), driveFileId);
+            String mimeType = provider.getFileMimeType(storage.accessToken(), driveFileId);
 
             log.info("Successfully proxied media: {} ({} bytes, type: {})",
                     driveFileId, content.length, mimeType);
@@ -54,7 +36,6 @@ public class RecipeMediaProxyService {
         } catch (Exception e) {
             log.error("Failed to proxy media file: {}", driveFileId, e);
 
-            // Check if it's a "not found" error from Drive API
             if (e.getMessage() != null &&
                     (e.getMessage().contains("404") || e.getMessage().contains("not found"))) {
                 throw new RecipeNotFoundException("Media file not found: " + driveFileId, e);
@@ -64,12 +45,6 @@ public class RecipeMediaProxyService {
         }
     }
 
-    /**
-     * Media content with data and MIME type.
-     *
-     * @param data     File content as bytes
-     * @param mimeType MIME type (e.g., "image/jpeg", "image/png")
-     */
     public record MediaContent(byte[] data, String mimeType) {
     }
 }

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/RecipeService.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/RecipeService.java
@@ -8,7 +8,6 @@ import net.shamansoft.cookbook.dto.RecipeDto;
 import net.shamansoft.cookbook.dto.RecipeItemResult;
 import net.shamansoft.cookbook.dto.RecipeResponse;
 import net.shamansoft.cookbook.dto.StorageInfo;
-import net.shamansoft.cookbook.dto.StorageType;
 import net.shamansoft.cookbook.exception.RecipeNotFoundException;
 import net.shamansoft.cookbook.exception.StorageNotConnectedException;
 import net.shamansoft.cookbook.html.HtmlExtractor;
@@ -25,8 +24,7 @@ import java.util.Optional;
 
 /**
  * Core business logic for recipe operations.
- * Orchestrates Drive access, YAML parsing, and DTO mapping.
- * Supports extracting multiple recipes from a single page.
+ * Routes storage I/O to the provider selected by the user's connected storage type.
  */
 @Service
 @RequiredArgsConstructor
@@ -34,7 +32,7 @@ import java.util.Optional;
 public class RecipeService {
 
     private final ContentHashService contentHashService;
-    private final DriveService googleDriveService;
+    private final StorageProviderResolver storageProviderResolver;
     private final StorageService storageService;
     private final RecipeStoreService recipeStoreService;
     private final RecipeParser recipeParser;
@@ -50,8 +48,10 @@ public class RecipeService {
 
         if (storage.folderId() == null) {
             throw new StorageNotConnectedException(
-                    "No folder configured for recipe storage. Please reconnect Google Drive or configure a folder.");
+                    "No folder configured for recipe storage. Please reconnect storage or configure a folder.");
         }
+
+        StorageProvider provider = storageProviderResolver.resolve(storage.type());
 
         var transformerResponse = createOrGetCached(url, sourceHtml, compression);
         RecipeResponse.RecipeResponseBuilder responseBuilder = RecipeResponse.builder()
@@ -65,9 +65,9 @@ public class RecipeService {
             for (Recipe recipe : transformerResponse.recipes()) {
                 String recipeTitle = recipe.metadata() != null && recipe.metadata().title() != null
                         ? recipe.metadata().title() : title;
-                String fileName = googleDriveService.generateFileName(recipeTitle);
+                String fileName = provider.generateFileName(recipeTitle);
                 String yamlContent = convertRecipeToYaml(recipe);
-                DriveService.UploadResult uploadResult = googleDriveService.uploadRecipeYaml(
+                DriveService.UploadResult uploadResult = provider.uploadRecipeYaml(
                         storage.accessToken(), storage.folderId(), fileName, yamlContent);
                 uploadedRecipes.add(new RecipeItemResult(recipeTitle, uploadResult.fileId(), uploadResult.fileUrl()));
             }
@@ -83,7 +83,7 @@ public class RecipeService {
                         .driveFileUrl(first.driveFileUrl());
             }
         } else {
-            log.info("Content is not a recipe. Skipping Drive storage - URL: {}", url);
+            log.info("Content is not a recipe. Skipping storage - URL: {}", url);
         }
 
         return responseBuilder.build();
@@ -94,8 +94,10 @@ public class RecipeService {
 
         if (storage.folderId() == null) {
             throw new StorageNotConnectedException(
-                    "No folder configured for recipe storage. Please reconnect Google Drive or configure a folder.");
+                    "No folder configured for recipe storage. Please reconnect storage or configure a folder.");
         }
+
+        StorageProvider provider = storageProviderResolver.resolve(storage.type());
 
         String plainDescription = decompressContent(description, compression);
         var transformerResponse = geminiRestTransformer.transformDescription(plainDescription);
@@ -104,9 +106,9 @@ public class RecipeService {
         for (Recipe recipe : transformerResponse.recipes()) {
             String recipeTitle = recipe.metadata() != null && recipe.metadata().title() != null
                     ? recipe.metadata().title() : title;
-            String fileName = googleDriveService.generateFileName(recipeTitle);
+            String fileName = provider.generateFileName(recipeTitle);
             String yamlContent = convertRecipeToYaml(recipe);
-            DriveService.UploadResult uploadResult = googleDriveService.uploadRecipeYaml(
+            DriveService.UploadResult uploadResult = provider.uploadRecipeYaml(
                     storage.accessToken(), storage.folderId(), fileName, yamlContent);
             uploadedRecipes.add(new RecipeItemResult(recipeTitle, uploadResult.fileId(), uploadResult.fileUrl()));
         }
@@ -167,14 +169,7 @@ public class RecipeService {
     }
 
     /**
-     * List all recipes from user's Drive folder with full parsing.
-     *
-     * @param userId    Firebase user ID
-     * @param pageSize  Number of items per page (1-100)
-     * @param pageToken Pagination token from previous response (null for first page)
-     * @return RecipeListResult with recipes and next page token
-     * @throws net.shamansoft.cookbook.exception.StorageNotConnectedException if storage not connected
-     * @throws net.shamansoft.cookbook.exception.DatabaseUnavailableException if Firestore unavailable
+     * List all recipes from the user's storage folder with full parsing.
      */
     public RecipeListResult listRecipes(String userId, int pageSize, String pageToken) {
         log.info("Listing recipes for user: {}, pageSize: {}, pageToken: {}",
@@ -182,25 +177,22 @@ public class RecipeService {
 
         StorageInfo storage = storageService.getStorageInfo(userId);
 
-        if (storage.type() != StorageType.GOOGLE_DRIVE) {
-            throw new IllegalStateException("Expected Google Drive storage, got: " + storage.type());
-        }
-
         if (storage.folderId() == null) {
             throw new StorageNotConnectedException(
-                    "No folder configured for recipe storage. Please reconnect Google Drive or configure a folder.");
+                    "No folder configured for recipe storage. Please reconnect storage or configure a folder.");
         }
 
+        StorageProvider provider = storageProviderResolver.resolve(storage.type());
         String folderId = storage.folderId();
         log.debug("Using folder ID from user profile: {}", folderId);
 
-        GoogleDrive.DriveFileListResult driveFiles = googleDriveService.listRecipeFiles(
+        GoogleDrive.DriveFileListResult driveFiles = provider.listRecipeFiles(
                 storage.accessToken(), folderId, pageSize, pageToken);
 
         log.info("Found {} YAML files in folder: {}", driveFiles.files().size(), folderId);
 
         List<RecipeDto> recipes = driveFiles.files().stream()
-                .map(file -> parseRecipeFile(storage.accessToken(), file))
+                .map(file -> parseRecipeFile(provider, storage.accessToken(), file))
                 .filter(Objects::nonNull)
                 .toList();
 
@@ -210,31 +202,21 @@ public class RecipeService {
     }
 
     /**
-     * Get single recipe by Drive file ID.
-     *
-     * @param userId Firebase user ID
-     * @param fileId Google Drive file ID
-     * @return Recipe DTO with full data
-     * @throws net.shamansoft.cookbook.exception.StorageNotConnectedException if storage not connected
-     * @throws RecipeNotFoundException                                        if file not found
-     * @throws net.shamansoft.cookbook.exception.InvalidRecipeFormatException if YAML invalid
+     * Get single recipe by storage file ID.
      */
     public RecipeDto getRecipe(String userId, String fileId) {
         log.info("Getting recipe: {} for user: {}", fileId, userId);
 
         StorageInfo storage = storageService.getStorageInfo(userId);
-
-        if (storage.type() != StorageType.GOOGLE_DRIVE) {
-            throw new IllegalStateException("Expected Google Drive storage, got: " + storage.type());
-        }
+        StorageProvider provider = storageProviderResolver.resolve(storage.type());
 
         try {
-            GoogleDrive.DriveFileMetadata metadata = googleDriveService.getFileMetadata(
+            GoogleDrive.DriveFileMetadata metadata = provider.getFileMetadata(
                     storage.accessToken(), fileId);
 
             log.debug("Found file: {} ({})", metadata.name(), metadata.mimeType());
 
-            String yamlContent = googleDriveService.getFileContent(storage.accessToken(), fileId);
+            String yamlContent = provider.getFileContent(storage.accessToken(), fileId);
             Recipe recipe = recipeParser.parse(yamlContent);
             RecipeDto dto = recipeMapper.toDto(recipe, metadata);
 
@@ -253,10 +235,10 @@ public class RecipeService {
         }
     }
 
-    private RecipeDto parseRecipeFile(String authToken, GoogleDrive.DriveFileInfo fileInfo) {
+    private RecipeDto parseRecipeFile(StorageProvider provider, String authToken, GoogleDrive.DriveFileInfo fileInfo) {
         try {
             log.debug("Parsing recipe file: {} ({})", fileInfo.name(), fileInfo.id());
-            String yamlContent = googleDriveService.getFileContent(authToken, fileInfo.id());
+            String yamlContent = provider.getFileContent(authToken, fileInfo.id());
             Recipe recipe = recipeParser.parse(yamlContent);
             RecipeDto dto = recipeMapper.toDto(recipe, fileInfo);
             log.debug("Successfully parsed: {}", dto.getTitle());
@@ -270,7 +252,6 @@ public class RecipeService {
 
     /**
      * Decompresses content only when compression is BASE64_GZIP.
-     * Null or NONE compression passes content through unchanged.
      */
     private String decompressContent(String content, Compression compression) throws IOException {
         if (content == null || content.isBlank()) return content;
@@ -288,12 +269,6 @@ public class RecipeService {
         }
     }
 
-    /**
-     * Result of listing recipes with pagination.
-     *
-     * @param recipes       List of recipe DTOs
-     * @param nextPageToken Token for next page (null if no more pages)
-     */
     public record RecipeListResult(List<RecipeDto> recipes, String nextPageToken) {
     }
 }

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/StorageProvider.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/StorageProvider.java
@@ -1,0 +1,39 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.client.GoogleDrive;
+import net.shamansoft.cookbook.dto.StorageType;
+
+/**
+ * Provider-agnostic storage operation surface used by RecipeService / RecipeMediaProxyService.
+ * Method names mirror {@link DriveService} so existing consumers change only which bean they call.
+ */
+public interface StorageProvider {
+
+    StorageType type();
+
+    String generateFileName(String title);
+
+    /**
+     * Ensure the recipe folder exists.
+     *
+     * @param accessToken provider access token
+     * @param folderName  desired folder name (may be blank → provider default / app-folder root)
+     * @return the folder reference (id may be a Drive id, or a Dropbox path such as "" or "/Sub")
+     */
+    FolderRef getOrCreateFolder(String accessToken, String folderName);
+
+    DriveService.UploadResult uploadRecipeYaml(String accessToken, String folderId, String fileName, String content);
+
+    GoogleDrive.DriveFileListResult listRecipeFiles(String accessToken, String folderId, int pageSize, String pageToken);
+
+    String getFileContent(String accessToken, String fileId);
+
+    byte[] downloadFile(String accessToken, String fileId);
+
+    String getFileMimeType(String accessToken, String fileId);
+
+    GoogleDrive.DriveFileMetadata getFileMetadata(String accessToken, String fileId);
+
+    record FolderRef(String id, String name) {
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/StorageProviderResolver.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/StorageProviderResolver.java
@@ -1,0 +1,31 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.dto.StorageType;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Selects the {@link StorageProvider} implementation for a given {@link StorageType}.
+ */
+@Service
+public class StorageProviderResolver {
+
+    private final Map<StorageType, StorageProvider> byType = new EnumMap<>(StorageType.class);
+
+    public StorageProviderResolver(List<StorageProvider> providers) {
+        for (StorageProvider provider : providers) {
+            byType.put(provider.type(), provider);
+        }
+    }
+
+    public StorageProvider resolve(StorageType type) {
+        StorageProvider provider = byType.get(type);
+        if (provider == null) {
+            throw new IllegalStateException("No storage provider registered for type: " + type);
+        }
+        return provider;
+    }
+}

--- a/extractor/src/main/java/net/shamansoft/cookbook/service/StorageService.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/service/StorageService.java
@@ -4,6 +4,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import lombok.extern.slf4j.Slf4j;
+import net.shamansoft.cookbook.client.DropboxAuthClient;
 import net.shamansoft.cookbook.client.GoogleAuthClient;
 import net.shamansoft.cookbook.client.GoogleDrive;
 import net.shamansoft.cookbook.client.GoogleDrive.Item;
@@ -33,17 +34,25 @@ public class StorageService {
     private final TokenEncryptionService tokenEncryptionService;
     private final GoogleAuthClient googleAuthClient;
     private final GoogleDrive googleDrive;
+    private final DropboxAuthClient dropboxAuthClient;
+    private final DropboxStorageProvider dropboxStorageProvider;
     @Value("${cookbook.drive.folder-name}")
     private String defaultFolderName;
+    @Value("${cookbook.dropbox.folder-name:}")
+    private String defaultDropboxFolderName;
 
     public StorageService(Firestore firestore,
                           TokenEncryptionService tokenEncryptionService,
                           GoogleAuthClient googleAuthClient,
-                          GoogleDrive googleDrive) {
+                          GoogleDrive googleDrive,
+                          DropboxAuthClient dropboxAuthClient,
+                          DropboxStorageProvider dropboxStorageProvider) {
         this.firestore = firestore;
         this.tokenEncryptionService = tokenEncryptionService;
         this.googleAuthClient = googleAuthClient;
         this.googleDrive = googleDrive;
+        this.dropboxAuthClient = dropboxAuthClient;
+        this.dropboxStorageProvider = dropboxStorageProvider;
     }
 
     /**
@@ -182,6 +191,71 @@ public class StorageService {
     }
 
     /**
+     * Connect Dropbox storage: exchange the authorization code, provision the app-folder
+     * (or an optional subfolder), and store the encrypted connection.
+     */
+    public FolderInfo connectDropbox(String userId, String authorizationCode, String redirectUri,
+                                     String folderName) {
+        log.info("Connecting Dropbox storage for user: {}", userId);
+        try {
+            DropboxAuthClient.TokenResponse tokens =
+                    dropboxAuthClient.exchangeAuthorizationCode(authorizationCode, redirectUri);
+
+            String resolvedFolderName = (folderName == null || folderName.isBlank())
+                    ? defaultDropboxFolderName
+                    : folderName.trim();
+
+            StorageProvider.FolderRef folder =
+                    dropboxStorageProvider.getOrCreateFolder(tokens.accessToken(), resolvedFolderName);
+            log.info("Using Dropbox folder '{}' (id='{}')", folder.name(), folder.id());
+
+            storeConnection(userId, StorageType.DROPBOX, tokens.accessToken(), tokens.refreshToken(),
+                    tokens.expiresIn(), folder.id(), folder.name());
+
+            return new FolderInfo(folder.id(), folder.name());
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to connect Dropbox for user {}: {}", userId, e.getMessage(), e);
+            throw new DatabaseUnavailableException("Failed to connect Dropbox: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Persist an encrypted storage connection of any provider type.
+     */
+    private void storeConnection(String userId, StorageType type, String accessToken, String refreshToken,
+                                 long expiresIn, String folderId, String folderName) {
+        try {
+            StorageEntity storageEntity = StorageEntity.builder()
+                    .type(type.getFirestoreValue())
+                    .connected(true)
+                    .accessToken(tokenEncryptionService.encrypt(accessToken))
+                    .refreshToken(refreshToken != null ? tokenEncryptionService.encrypt(refreshToken) : null)
+                    .expiresAt(Timestamp.ofTimeSecondsAndNanos(
+                            System.currentTimeMillis() / 1000 + expiresIn, 0))
+                    .connectedAt(Timestamp.now())
+                    .folderId(folderId)
+                    .folderName(folderName)
+                    .build();
+
+            firestore.collection(USERS_COLLECTION)
+                    .document(userId)
+                    .update(STORAGE_FIELD, storageEntity.toMap())
+                    .get();
+
+            log.info("{} connected successfully for user: {}", type, userId);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DatabaseUnavailableException("Failed to store connection: operation interrupted", e);
+        } catch (ExecutionException e) {
+            throw new DatabaseUnavailableException("Failed to store connection", e);
+        } catch (Exception e) {
+            throw new DatabaseUnavailableException("Failed to encrypt tokens or update Firestore", e);
+        }
+    }
+
+    /**
      * Refresh access token using refresh token
      */
     private StorageInfo getFreshStorageInfo(String userId, StorageEntity storage) {
@@ -196,19 +270,33 @@ public class StorageService {
 
             log.info("Refreshing OAuth token for user: {}", userId);
 
-            // Call GoogleAuthClient to refresh token
-            GoogleAuthClient.RefreshTokenResponse response = googleAuthClient.refreshAccessToken(refreshToken);
+            // Refresh via the provider's auth client, selected by stored type.
+            StorageType storageType = storage.type() != null
+                    ? StorageType.fromFirestoreValue(storage.type())
+                    : StorageType.GOOGLE_DRIVE;
+
+            final String newAccessToken;
+            final Timestamp newExpiresAt;
+            if (storageType == StorageType.DROPBOX) {
+                DropboxAuthClient.RefreshTokenResponse response = dropboxAuthClient.refreshAccessToken(refreshToken);
+                newAccessToken = response.accessToken();
+                newExpiresAt = response.expiresAt();
+            } else {
+                GoogleAuthClient.RefreshTokenResponse response = googleAuthClient.refreshAccessToken(refreshToken);
+                newAccessToken = response.accessToken();
+                newExpiresAt = response.expiresAt();
+            }
 
             log.info("Successfully refreshed OAuth token for user: {}", userId);
 
             // Update Firestore with new token
-            String encryptedAccessToken = tokenEncryptionService.encrypt(response.accessToken());
+            String encryptedAccessToken = tokenEncryptionService.encrypt(newAccessToken);
 
             firestore.collection(USERS_COLLECTION)
                     .document(userId)
                     .update(
                             STORAGE_FIELD + ".accessToken", encryptedAccessToken,
-                            STORAGE_FIELD + ".expiresAt", response.expiresAt()
+                            STORAGE_FIELD + ".expiresAt", newExpiresAt
                     )
                     .get();
 
@@ -216,11 +304,11 @@ public class StorageService {
 
             // Return StorageInfo with new token
             return StorageInfo.builder()
-                    .type(StorageType.fromFirestoreValue(storage.type()))
+                    .type(storageType)
                     .connected(true)
-                    .accessToken(response.accessToken())  // Decrypted new token
+                    .accessToken(newAccessToken)  // Decrypted new token
                     .refreshToken(refreshToken)   // Keep same refresh token
-                    .expiresAt(response.expiresAt().toDate().toInstant())
+                    .expiresAt(newExpiresAt.toDate().toInstant())
                     .connectedAt(storage.connectedAt() != null
                             ? storage.connectedAt().toDate().toInstant()
                             : null)
@@ -289,8 +377,14 @@ public class StorageService {
                 );
             }
 
-            // 4. Check if token needs refresh
-            if (googleAuthClient.isTokenExpired(storageEntity.expiresAt())) {
+            // 4. Check if token needs refresh (provider-aware)
+            StorageType storageType = storageEntity.type() != null
+                    ? StorageType.fromFirestoreValue(storageEntity.type())
+                    : StorageType.GOOGLE_DRIVE;
+            boolean expired = (storageType == StorageType.DROPBOX)
+                    ? dropboxAuthClient.isTokenExpired(storageEntity.expiresAt())
+                    : googleAuthClient.isTokenExpired(storageEntity.expiresAt());
+            if (expired) {
                 log.info("OAuth token expired or expiring soon for user: {}, refreshing...", userId);
                 return getFreshStorageInfo(userId, storageEntity);
             }
@@ -361,6 +455,7 @@ public class StorageService {
      * @param userId Firebase user ID
      */
     public void disconnectStorage(String userId) {
+        revokeProviderTokenBestEffort(userId);
         log.info("Disconnecting storage for user: {}", userId);
 
         try {
@@ -375,6 +470,34 @@ public class StorageService {
             throw new DatabaseUnavailableException("Failed to disconnect storage: operation interrupted", e);
         } catch (ExecutionException e) {
             throw new DatabaseUnavailableException("Failed to disconnect storage", e);
+        }
+    }
+
+    /**
+     * If the connected provider is Dropbox, revoke its token server-side before disconnect.
+     * Best-effort: never blocks or fails the disconnect.
+     */
+    @SuppressWarnings("unchecked")
+    private void revokeProviderTokenBestEffort(String userId) {
+        try {
+            DocumentSnapshot doc = firestore.collection(USERS_COLLECTION)
+                    .document(userId).get().get();
+            Map<String, Object> storageMap = (Map<String, Object>) doc.get("storage");
+            if (storageMap == null) {
+                return;
+            }
+            String type = (String) storageMap.get("type");
+            if (!StorageType.DROPBOX.getFirestoreValue().equals(type)) {
+                return;
+            }
+            String encryptedAccess = (String) storageMap.get("accessToken");
+            if (encryptedAccess == null) {
+                return;
+            }
+            String accessToken = tokenEncryptionService.decrypt(encryptedAccess);
+            dropboxAuthClient.revokeToken(accessToken);
+        } catch (Exception e) {
+            log.warn("Best-effort Dropbox token revoke failed for user {}: {}", userId, e.getMessage());
         }
     }
 

--- a/extractor/src/main/resources/application.yaml
+++ b/extractor/src/main/resources/application.yaml
@@ -254,6 +254,17 @@ cookbook:
     oauth-secret: "${SAR_SRV_GOOGLE_OAUTH_SECRET:REPLACE_WITH_YOUR_OAUTH_SECRET}"
 
   # ---------------------------------------------------------------------------
+  # DROPBOX CONFIGURATION (App-folder access level)
+  # ---------------------------------------------------------------------------
+  dropbox:
+    # Dropbox app key (public value, safe in clients). Used by DropboxAuthClient.
+    app-key: "${COOKBOOK_DROPBOX_APP_KEY:REPLACE_WITH_DROPBOX_APP_KEY}"
+    # Dropbox app secret — provisioned via Secret Manager in sar-infra. NEVER commit a real value.
+    app-secret: "${COOKBOOK_DROPBOX_APP_SECRET:REPLACE_WITH_DROPBOX_APP_SECRET}"
+    # Default recipe subfolder inside the app folder. Empty = app-folder root ("").
+    folder-name: "${COOKBOOK_DROPBOX_FOLDER_NAME:}"
+
+  # ---------------------------------------------------------------------------
   # LEGACY GOOGLE OAUTH CONFIGURATION (UserProfileService)
   # ---------------------------------------------------------------------------
   google:

--- a/extractor/src/test/java/net/shamansoft/cookbook/client/DropboxAuthClientTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/client/DropboxAuthClientTest.java
@@ -1,0 +1,104 @@
+package net.shamansoft.cookbook.client;
+
+import com.google.cloud.Timestamp;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+class DropboxAuthClientTest {
+
+    private DropboxAuthClient newClient(RestClient restClient) {
+        DropboxAuthClient client = new DropboxAuthClient(restClient);
+        ReflectionTestUtils.setField(client, "appKey", "app-key");
+        ReflectionTestUtils.setField(client, "appSecret", "app-secret");
+        return client;
+    }
+
+    private RestClient.ResponseSpec stubPost(RestClient restClient) {
+        RestClient.RequestBodyUriSpec bodySpec = mock(RestClient.RequestBodyUriSpec.class);
+        RestClient.RequestBodySpec reqSpec = mock(RestClient.RequestBodySpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+        when(restClient.post()).thenReturn(bodySpec);
+        when(bodySpec.uri(anyString())).thenReturn(reqSpec);
+        when(reqSpec.contentType(any(MediaType.class))).thenReturn(reqSpec);
+        when(reqSpec.body(any(Object.class))).thenReturn(reqSpec);
+        when(reqSpec.retrieve()).thenReturn(responseSpec);
+        return responseSpec;
+    }
+
+    @Test
+    void exchangeAuthorizationCode_returnsTokens() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        Map<String, Object> response = new HashMap<>();
+        response.put("access_token", "dbx-access");
+        response.put("refresh_token", "dbx-refresh");
+        response.put("expires_in", 14400);
+        when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(response);
+
+        DropboxAuthClient.TokenResponse result =
+                newClient(restClient).exchangeAuthorizationCode("code", "sar://dropbox-callback");
+
+        assertThat(result.accessToken()).isEqualTo("dbx-access");
+        assertThat(result.refreshToken()).isEqualTo("dbx-refresh");
+        assertThat(result.expiresIn()).isEqualTo(14400);
+    }
+
+    @Test
+    void exchangeAuthorizationCode_missingRefreshToken_throwsIllegalState() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        Map<String, Object> response = new HashMap<>();
+        response.put("access_token", "dbx-access");
+        when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(response);
+
+        assertThatThrownBy(() -> newClient(restClient).exchangeAuthorizationCode("code", "sar://cb"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void refreshAccessToken_returnsNewAccessTokenAndExpiry() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        Map<String, Object> response = new HashMap<>();
+        response.put("access_token", "dbx-new");
+        response.put("expires_in", 14400);
+        when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(response);
+
+        DropboxAuthClient.RefreshTokenResponse result =
+                newClient(restClient).refreshAccessToken("dbx-refresh");
+
+        assertThat(result.accessToken()).isEqualTo("dbx-new");
+        assertThat(result.expiresAt()).isNotNull();
+    }
+
+    @Test
+    void isTokenExpired_nullOrPast_true_future_false() {
+        DropboxAuthClient client = newClient(mock(RestClient.class));
+        long now = System.currentTimeMillis() / 1000;
+        assertThat(client.isTokenExpired(null)).isTrue();
+        assertThat(client.isTokenExpired(Timestamp.ofTimeSecondsAndNanos(now - 60, 0))).isTrue();
+        assertThat(client.isTokenExpired(Timestamp.ofTimeSecondsAndNanos(now + 3600, 0))).isFalse();
+    }
+
+    @Test
+    void revokeToken_swallowsErrors() {
+        RestClient restClient = mock(RestClient.class);
+        when(restClient.post()).thenThrow(new RuntimeException("boom"));
+        assertThatCode(() -> newClient(restClient).revokeToken("dbx-access")).doesNotThrowAnyException();
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/client/DropboxClientTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/client/DropboxClientTest.java
@@ -1,0 +1,123 @@
+package net.shamansoft.cookbook.client;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+class DropboxClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Stub restClient.post().uri(str).header(...).header(...).contentType(...).body(...).retrieve() */
+    private RestClient.ResponseSpec stubPost(RestClient restClient) {
+        RestClient.RequestBodyUriSpec bodySpec = mock(RestClient.RequestBodyUriSpec.class);
+        RestClient.RequestBodySpec reqSpec = mock(RestClient.RequestBodySpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+        when(restClient.post()).thenReturn(bodySpec);
+        when(bodySpec.uri(anyString())).thenReturn(reqSpec);
+        when(reqSpec.header(anyString(), anyString())).thenReturn(reqSpec);
+        when(reqSpec.contentType(any(MediaType.class))).thenReturn(reqSpec);
+        doReturn(reqSpec).when(reqSpec).body(any(Object.class));
+        when(reqSpec.retrieve()).thenReturn(responseSpec);
+        return responseSpec;
+    }
+
+    @Test
+    void createFolder_conflict409_treatedAsExists() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientResponseException("conflict", 409, "Conflict", null, null, null));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        assertThatCode(() -> client.createFolder("/MyKukBuk", "token")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void createFolder_otherError_throwsClientException() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientResponseException("server error", 500, "Error", null, null, null));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        assertThatThrownBy(() -> client.createFolder("/MyKukBuk", "token"))
+                .isInstanceOf(ClientException.class);
+    }
+
+    @Test
+    void upload_returnsFileEntryWithId() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenReturn(Map.of("id", "id:abc123", "name", "pasta.yaml", "path_display", "/pasta.yaml"));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        DropboxClient.FileEntry entry = client.upload("/pasta.yaml", "content".getBytes(), "token");
+
+        assertThat(entry.id()).isEqualTo("id:abc123");
+        assertThat(entry.name()).isEqualTo("pasta.yaml");
+        assertThat(entry.pathDisplay()).isEqualTo("/pasta.yaml");
+    }
+
+    @Test
+    void downloadAsString_returnsUtf8() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        when(responseSpec.body(byte[].class))
+                .thenReturn("title: Хачапури".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        assertThat(client.downloadAsString("id:abc", "token")).isEqualTo("title: Хачапури");
+    }
+
+    @Test
+    void listFolder_filtersToFilesAndMapsCursor() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        Map<String, Object> file = Map.of(".tag", "file", "id", "id:f1", "name", "a.yaml",
+                "path_display", "/a.yaml", "server_modified", "2024-01-15T10:00:00Z");
+        Map<String, Object> folder = Map.of(".tag", "folder", "id", "id:d1", "name", "sub");
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenReturn(Map.of("entries", List.of(file, folder), "cursor", "CURSOR1", "has_more", true));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        DropboxClient.ListResult result = client.listFolder("", 100, "token");
+
+        assertThat(result.files()).hasSize(1);
+        assertThat(result.files().get(0).id()).isEqualTo("id:f1");
+        assertThat(result.cursor()).isEqualTo("CURSOR1");
+        assertThat(result.hasMore()).isTrue();
+    }
+
+    @Test
+    void getMetadata_returnsFileEntry() {
+        RestClient restClient = mock(RestClient.class);
+        RestClient.ResponseSpec responseSpec = stubPost(restClient);
+        when(responseSpec.body(any(ParameterizedTypeReference.class)))
+                .thenReturn(Map.of("id", "id:abc", "name", "photo.jpg",
+                        "path_display", "/photo.jpg", "server_modified", "2024-02-01T00:00:00Z"));
+
+        DropboxClient client = new DropboxClient(restClient, objectMapper);
+        DropboxClient.FileEntry entry = client.getMetadata("id:abc", "token");
+
+        assertThat(entry.name()).isEqualTo("photo.jpg");
+        assertThat(entry.serverModified()).isEqualTo("2024-02-01T00:00:00Z");
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/controller/StorageControllerTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/controller/StorageControllerTest.java
@@ -315,4 +315,90 @@ class StorageControllerTest {
                 controller.getGoogleDriveStatus(TEST_USER_ID)
         ).isInstanceOf(DatabaseUnavailableException.class);
     }
+
+    // ========== DROPBOX + NEUTRAL TESTS ==========
+
+    @Test
+    @DisplayName("POST /dropbox/connect - Success")
+    void connectDropbox_Success() {
+        StorageConnectionRequest request = StorageConnectionRequest.builder()
+                .authorizationCode(TEST_AUTH_CODE)
+                .redirectUri(TEST_REDIRECT_URI)
+                .folderName(null)
+                .build();
+        when(storageService.connectDropbox(eq(TEST_USER_ID), eq(TEST_AUTH_CODE), eq(TEST_REDIRECT_URI), isNull()))
+                .thenReturn(new StorageService.FolderInfo("", "MyKukBuk"));
+
+        ResponseEntity<StorageConnectionResponse> response =
+                controller.connectDropbox(TEST_USER_ID, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().getStatus()).isEqualTo("success");
+        assertThat(response.getBody().getMessage()).isEqualTo("Dropbox connected successfully");
+        assertThat(response.getBody().isConnected()).isTrue();
+        assertThat(response.getBody().getDefaultFolderId()).isEqualTo("");
+        assertThat(response.getBody().getDefaultFolderName()).isEqualTo("MyKukBuk");
+    }
+
+    @Test
+    @DisplayName("POST /dropbox/connect - Invalid code returns 400")
+    void connectDropbox_InvalidCode_Returns400() {
+        StorageConnectionRequest request = StorageConnectionRequest.builder()
+                .authorizationCode("bad")
+                .redirectUri(TEST_REDIRECT_URI)
+                .build();
+        doThrow(new IllegalArgumentException("Invalid authorization code"))
+                .when(storageService).connectDropbox(anyString(), anyString(), anyString(), any());
+
+        ResponseEntity<StorageConnectionResponse> response =
+                controller.connectDropbox(TEST_USER_ID, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getStatus()).isEqualTo("error");
+    }
+
+    @Test
+    @DisplayName("GET /status - neutral status returns connected provider")
+    void getStatus_Connected() {
+        StorageInfo storageInfo = StorageInfo.builder()
+                .type(StorageType.DROPBOX)
+                .connected(true)
+                .accessToken("t")
+                .folderId("")
+                .folderName("MyKukBuk")
+                .build();
+        when(storageService.getStorageInfo(TEST_USER_ID)).thenReturn(storageInfo);
+
+        ResponseEntity<StorageStatusResponse> response = controller.getStatus(TEST_USER_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().isConnected()).isTrue();
+        assertThat(response.getBody().getStorageType()).isEqualTo("dropbox");
+    }
+
+    @Test
+    @DisplayName("GET /status - not connected returns connected=false")
+    void getStatus_NotConnected() {
+        when(storageService.getStorageInfo(TEST_USER_ID))
+                .thenThrow(new StorageNotConnectedException("none"));
+
+        ResponseEntity<StorageStatusResponse> response = controller.getStatus(TEST_USER_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().isConnected()).isFalse();
+        assertThat(response.getBody().getStorageType()).isNull();
+    }
+
+    @Test
+    @DisplayName("DELETE /disconnect - neutral disconnect")
+    void disconnect_Neutral() {
+        doNothing().when(storageService).disconnectStorage(TEST_USER_ID);
+
+        ResponseEntity<StorageConnectionResponse> response = controller.disconnect(TEST_USER_ID);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().isConnected()).isFalse();
+        assertThat(response.getBody().getMessage()).isEqualTo("Storage disconnected successfully");
+        verify(storageService).disconnectStorage(TEST_USER_ID);
+    }
 }

--- a/extractor/src/test/java/net/shamansoft/cookbook/repository/firestore/model/StorageEntityTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/repository/firestore/model/StorageEntityTest.java
@@ -1,0 +1,39 @@
+package net.shamansoft.cookbook.repository.firestore.model;
+
+import net.shamansoft.cookbook.dto.StorageType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StorageEntityTest {
+
+    @Test
+    void toMap_persistsDropboxType() {
+        StorageEntity entity = StorageEntity.builder()
+                .type(StorageType.DROPBOX.getFirestoreValue())
+                .connected(true)
+                .accessToken("enc-access")
+                .folderId("")
+                .folderName("MyKukBuk")
+                .build();
+
+        Map<String, Object> map = entity.toMap();
+
+        assertThat(map.get("type")).isEqualTo("dropbox");
+        assertThat(map.get("connected")).isEqualTo(true);
+        assertThat(map.get("folderId")).isEqualTo("");
+    }
+
+    @Test
+    void toMap_persistsGoogleDriveType() {
+        StorageEntity entity = StorageEntity.builder()
+                .type(StorageType.GOOGLE_DRIVE.getFirestoreValue())
+                .connected(true)
+                .accessToken("enc-access")
+                .build();
+
+        assertThat(entity.toMap().get("type")).isEqualTo("googleDrive");
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/DropboxStorageProviderTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/DropboxStorageProviderTest.java
@@ -1,0 +1,149 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.client.DropboxClient;
+import net.shamansoft.cookbook.client.GoogleDrive;
+import net.shamansoft.cookbook.dto.StorageType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DropboxStorageProviderTest {
+
+    @Mock
+    private DropboxClient dropboxClient;
+    @Mock
+    private Transliterator transliterator;
+
+    @InjectMocks
+    private DropboxStorageProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(provider, "folderName", "");
+    }
+
+    @Test
+    void type_isDropbox() {
+        assertThat(provider.type()).isEqualTo(StorageType.DROPBOX);
+    }
+
+    @Test
+    void generateFileName_kebabsAndAddsYaml() {
+        when(transliterator.toAsciiKebab("Хачапури")).thenReturn("khachapuri");
+        assertThat(provider.generateFileName("Хачапури")).isEqualTo("khachapuri.yaml");
+    }
+
+    @Test
+    void getOrCreateFolder_blank_returnsAppRoot_noApiCall() {
+        StorageProvider.FolderRef ref = provider.getOrCreateFolder("token", "");
+        assertThat(ref.id()).isEqualTo("");
+        verify(dropboxClient, never()).createFolder(any(), any());
+    }
+
+    @Test
+    void getOrCreateFolder_named_createsSubfolder() {
+        StorageProvider.FolderRef ref = provider.getOrCreateFolder("token", "MyKukBuk");
+        assertThat(ref.id()).isEqualTo("/MyKukBuk");
+        assertThat(ref.name()).isEqualTo("MyKukBuk");
+        verify(dropboxClient).createFolder("/MyKukBuk", "token");
+    }
+
+    @Test
+    void uploadRecipeYaml_appRoot_joinsPathAndReturnsId() {
+        when(dropboxClient.upload(any(), any(), eq("token")))
+                .thenReturn(new DropboxClient.FileEntry("id:abc", "a.yaml", "/a.yaml", null));
+
+        DriveService.UploadResult result = provider.uploadRecipeYaml("token", "", "a.yaml", "yaml-content");
+
+        ArgumentCaptor<String> path = ArgumentCaptor.forClass(String.class);
+        verify(dropboxClient).upload(path.capture(), any(), eq("token"));
+        assertThat(path.getValue()).isEqualTo("/a.yaml");
+        assertThat(result.fileId()).isEqualTo("id:abc");
+        assertThat(result.fileUrl()).isEqualTo("/a.yaml");
+    }
+
+    @Test
+    void uploadRecipeYaml_subfolder_joinsPath() {
+        when(dropboxClient.upload(any(), any(), eq("token")))
+                .thenReturn(new DropboxClient.FileEntry("id:abc", "a.yaml", "/MyKukBuk/a.yaml", null));
+
+        provider.uploadRecipeYaml("token", "/MyKukBuk", "a.yaml", "yaml");
+
+        ArgumentCaptor<String> path = ArgumentCaptor.forClass(String.class);
+        verify(dropboxClient).upload(path.capture(), any(), eq("token"));
+        assertThat(path.getValue()).isEqualTo("/MyKukBuk/a.yaml");
+    }
+
+    @Test
+    void listRecipeFiles_firstPage_filtersYamlAndMapsCursor() {
+        DropboxClient.FileEntry yaml = new DropboxClient.FileEntry("id:1", "a.yaml", "/a.yaml", "2024-01-15T10:00:00Z");
+        DropboxClient.FileEntry other = new DropboxClient.FileEntry("id:2", "note.txt", "/note.txt", "2024-01-16T10:00:00Z");
+        when(dropboxClient.listFolder("", 20, "token"))
+                .thenReturn(new DropboxClient.ListResult(List.of(yaml, other), "CUR", true));
+
+        GoogleDrive.DriveFileListResult result = provider.listRecipeFiles("token", "", 20, null);
+
+        assertThat(result.files()).hasSize(1);
+        assertThat(result.files().get(0).id()).isEqualTo("id:1");
+        assertThat(result.files().get(0).modifiedTime()).isEqualTo("2024-01-15T10:00:00Z");
+        assertThat(result.nextPageToken()).isEqualTo("CUR");
+    }
+
+    @Test
+    void listRecipeFiles_withPageToken_usesContinue_noMore() {
+        when(dropboxClient.listFolderContinue("CUR", "token"))
+                .thenReturn(new DropboxClient.ListResult(List.of(), null, false));
+
+        GoogleDrive.DriveFileListResult result = provider.listRecipeFiles("token", "", 20, "CUR");
+
+        assertThat(result.files()).isEmpty();
+        assertThat(result.nextPageToken()).isNull();
+    }
+
+    @Test
+    void getFileContent_delegates() {
+        when(dropboxClient.downloadAsString("id:abc", "token")).thenReturn("yaml");
+        assertThat(provider.getFileContent("token", "id:abc")).isEqualTo("yaml");
+    }
+
+    @Test
+    void downloadFile_delegates() {
+        byte[] bytes = {1, 2, 3};
+        when(dropboxClient.downloadAsBytes("id:abc", "token")).thenReturn(bytes);
+        assertThat(provider.downloadFile("token", "id:abc")).isEqualTo(bytes);
+    }
+
+    @Test
+    void getFileMimeType_inferredFromName() {
+        when(dropboxClient.getMetadata("id:img", "token"))
+                .thenReturn(new DropboxClient.FileEntry("id:img", "photo.jpg", "/photo.jpg", null));
+        assertThat(provider.getFileMimeType("token", "id:img")).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    void getFileMetadata_mapsWithInferredMime() {
+        when(dropboxClient.getMetadata("id:1", "token"))
+                .thenReturn(new DropboxClient.FileEntry("id:1", "a.yaml", "/a.yaml", "2024-01-15T10:00:00Z"));
+
+        GoogleDrive.DriveFileMetadata meta = provider.getFileMetadata("token", "id:1");
+
+        assertThat(meta.id()).isEqualTo("id:1");
+        assertThat(meta.name()).isEqualTo("a.yaml");
+        assertThat(meta.mimeType()).isEqualTo("application/x-yaml");
+        assertThat(meta.modifiedTime()).isEqualTo("2024-01-15T10:00:00Z");
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/GoogleDriveStorageProviderTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/GoogleDriveStorageProviderTest.java
@@ -1,0 +1,60 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.client.GoogleDrive;
+import net.shamansoft.cookbook.dto.StorageType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class GoogleDriveStorageProviderTest {
+
+    @Mock
+    private GoogleDriveService googleDriveService;
+
+    @InjectMocks
+    private GoogleDriveStorageProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(provider, "folderName", "_save_a_recipe");
+    }
+
+    @Test
+    void type_isGoogleDrive() {
+        assertThat(provider.type()).isEqualTo(StorageType.GOOGLE_DRIVE);
+    }
+
+    @Test
+    void getOrCreateFolder_delegatesAndUsesConfiguredName() {
+        when(googleDriveService.getOrCreateFolder("token")).thenReturn("folder-123");
+
+        StorageProvider.FolderRef ref = provider.getOrCreateFolder("token", "ignored");
+
+        assertThat(ref.id()).isEqualTo("folder-123");
+        assertThat(ref.name()).isEqualTo("_save_a_recipe");
+    }
+
+    @Test
+    void listRecipeFiles_delegates() {
+        GoogleDrive.DriveFileListResult expected =
+                new GoogleDrive.DriveFileListResult(java.util.List.of(), "next");
+        when(googleDriveService.listRecipeFiles("token", "folder", 20, null)).thenReturn(expected);
+
+        assertThat(provider.listRecipeFiles("token", "folder", 20, null)).isSameAs(expected);
+    }
+
+    @Test
+    void uploadRecipeYaml_delegates() {
+        DriveService.UploadResult expected = new DriveService.UploadResult("id1", "url1");
+        when(googleDriveService.uploadRecipeYaml("token", "folder", "a.yaml", "yaml")).thenReturn(expected);
+
+        assertThat(provider.uploadRecipeYaml("token", "folder", "a.yaml", "yaml")).isSameAs(expected);
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceCreateRecipeTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceCreateRecipeTest.java
@@ -56,7 +56,9 @@ class RecipeServiceCreateRecipeTest {
     @Mock
     private ContentHashService contentHashService;
     @Mock
-    private DriveService driveService;
+    private StorageProvider driveService;
+    @Mock
+    private StorageProviderResolver storageProviderResolver;
     @Mock
     private StorageService storageService;
     @Mock
@@ -81,7 +83,10 @@ class RecipeServiceCreateRecipeTest {
 
     @BeforeEach
     void setUp() {
-        recipeService = new RecipeService(contentHashService, driveService, storageService,
+        org.mockito.Mockito.lenient()
+                .when(storageProviderResolver.resolve(any(net.shamansoft.cookbook.dto.StorageType.class)))
+                .thenReturn(driveService);
+        recipeService = new RecipeService(contentHashService, storageProviderResolver, storageService,
                 recipeStoreService, recipeParser, recipeMapper, htmlExtractor,
                 compressor, transformer, validationService, geminiRestTransformer);
 

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceErrorHandlingTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceErrorHandlingTest.java
@@ -54,7 +54,9 @@ class RecipeServiceErrorHandlingTest {
     private ContentHashService contentHashService;
 
     @Mock
-    private DriveService driveService;
+    private StorageProvider driveService;
+    @Mock
+    private StorageProviderResolver storageProviderResolver;
 
     @Mock
     private StorageService storageService;
@@ -103,8 +105,11 @@ class RecipeServiceErrorHandlingTest {
             return storage;
         });
 
+        lenient()
+                .when(storageProviderResolver.resolve(any(net.shamansoft.cookbook.dto.StorageType.class)))
+                .thenReturn(driveService);
         recipeService = new RecipeService(
-                contentHashService, driveService, storageService, recipeStoreService,
+                contentHashService, storageProviderResolver, storageService, recipeStoreService,
                 recipeParser, recipeMapper, htmlExtractor, compressor, transformer,
                 validationService, geminiRestTransformer
         );

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceFromDescriptionTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceFromDescriptionTest.java
@@ -47,7 +47,9 @@ class RecipeServiceFromDescriptionTest {
     @Mock
     private ContentHashService contentHashService;
     @Mock
-    private DriveService driveService;
+    private StorageProvider driveService;
+    @Mock
+    private StorageProviderResolver storageProviderResolver;
     @Mock
     private StorageService storageService;
     @Mock
@@ -73,7 +75,10 @@ class RecipeServiceFromDescriptionTest {
 
     @BeforeEach
     void setUp() {
-        recipeService = new RecipeService(contentHashService, driveService, storageService,
+        org.mockito.Mockito.lenient()
+                .when(storageProviderResolver.resolve(any(net.shamansoft.cookbook.dto.StorageType.class)))
+                .thenReturn(driveService);
+        recipeService = new RecipeService(contentHashService, storageProviderResolver, storageService,
                 recipeStoreService, recipeParser, recipeMapper, htmlExtractor,
                 compressor, transformer, validationService, geminiRestTransformer);
         mockStorageInfo = StorageInfo.builder()

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceListGetTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceListGetTest.java
@@ -44,7 +44,8 @@ class RecipeServiceListGetTest {
     private static final String YAML = "is_recipe: true\ntitle: Test\n";
 
     @Mock private ContentHashService contentHashService;
-    @Mock private DriveService driveService;
+    @Mock private StorageProvider driveService;
+    @Mock private StorageProviderResolver storageProviderResolver;
     @Mock private StorageService storageService;
     @Mock private RecipeStoreService recipeStoreService;
     @Mock private RecipeParser recipeParser;
@@ -60,6 +61,9 @@ class RecipeServiceListGetTest {
 
     @BeforeEach
     void setUp() {
+        org.mockito.Mockito.lenient()
+                .when(storageProviderResolver.resolve(any(StorageType.class)))
+                .thenReturn(driveService);
         connectedStorage = StorageInfo.builder()
                 .type(StorageType.GOOGLE_DRIVE)
                 .connected(true)
@@ -152,19 +156,6 @@ class RecipeServiceListGetTest {
         verify(driveService, never()).listRecipeFiles(any(), any(), any(int.class), any());
     }
 
-    @Test
-    @DisplayName("listRecipes: throws IllegalStateException for non-Drive storage")
-    void listRecipes_throwsForWrongStorageType() {
-        StorageInfo dropbox = StorageInfo.builder()
-                .type(StorageType.DROPBOX).connected(true)
-                .accessToken(ACCESS_TOKEN).folderId(FOLDER_ID).build();
-        when(storageService.getStorageInfo(USER_ID)).thenReturn(dropbox);
-
-        assertThatThrownBy(() -> recipeService.listRecipes(USER_ID, 20, null))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("DROPBOX");
-    }
-
     // ---- getRecipe ----------------------------------------------------------
 
     @Test
@@ -222,18 +213,6 @@ class RecipeServiceListGetTest {
         assertThatThrownBy(() -> recipeService.getRecipe(USER_ID, FILE_ID))
                 .isInstanceOf(StorageNotConnectedException.class);
         verify(driveService, never()).getFileMetadata(anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("getRecipe: throws IllegalStateException for non-Drive storage")
-    void getRecipe_throwsForWrongStorageType() {
-        StorageInfo dropbox = StorageInfo.builder()
-                .type(StorageType.DROPBOX).connected(true)
-                .accessToken(ACCESS_TOKEN).folderId(FOLDER_ID).build();
-        when(storageService.getStorageInfo(USER_ID)).thenReturn(dropbox);
-
-        assertThatThrownBy(() -> recipeService.getRecipe(USER_ID, FILE_ID))
-                .isInstanceOf(IllegalStateException.class);
     }
 
     private Recipe createTestRecipe(String title) {

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/RecipeServiceTest.java
@@ -21,7 +21,9 @@ class RecipeServiceTest {
     void createRecipe_storesYaml_whenRecipeDetected() throws Exception {
         // Arrange: minimal happy path with many dependencies mocked
         ContentHashService contentHashService = mock(ContentHashService.class);
-        DriveService driveService = mock(DriveService.class);
+        StorageProvider driveService = mock(StorageProvider.class);
+        StorageProviderResolver storageProviderResolver = mock(StorageProviderResolver.class);
+        when(storageProviderResolver.resolve(any(net.shamansoft.cookbook.dto.StorageType.class))).thenReturn(driveService);
         StorageService storageService = mock(StorageService.class);
         RecipeStoreService recipeStoreService = mock(RecipeStoreService.class);
         RecipeParser recipeParser = mock(RecipeParser.class);
@@ -61,7 +63,7 @@ class RecipeServiceTest {
         // Build service (AdaptiveCleaningTransformerService now owns cleaning; no HtmlCleaner in RecipeService)
         Compressor compressor = mock(Compressor.class);
         GeminiRestTransformer geminiRestTransformer = mock(GeminiRestTransformer.class);
-        RecipeService svc = new RecipeService(contentHashService, driveService, storageService, recipeStoreService,
+        RecipeService svc = new RecipeService(contentHashService, storageProviderResolver, storageService, recipeStoreService,
                 recipeParser, recipeMapper, htmlExtractor, compressor, transformer, validationService, geminiRestTransformer);
 
         // Act
@@ -76,7 +78,9 @@ class RecipeServiceTest {
     @Test
     void createRecipe_throwsWhenNoFolder() throws IOException {
         ContentHashService contentHashService = mock(ContentHashService.class);
-        DriveService driveService = mock(DriveService.class);
+        StorageProvider driveService = mock(StorageProvider.class);
+        StorageProviderResolver storageProviderResolver = mock(StorageProviderResolver.class);
+        when(storageProviderResolver.resolve(any(net.shamansoft.cookbook.dto.StorageType.class))).thenReturn(driveService);
         StorageService storageService = mock(StorageService.class);
         RecipeStoreService recipeStoreService = mock(RecipeStoreService.class);
         RecipeParser recipeParser = mock(RecipeParser.class);
@@ -92,7 +96,7 @@ class RecipeServiceTest {
 
         Compressor compressor = mock(Compressor.class);
         GeminiRestTransformer geminiRestTransformer = mock(GeminiRestTransformer.class);
-        RecipeService svc = new RecipeService(contentHashService, driveService, storageService, recipeStoreService,
+        RecipeService svc = new RecipeService(contentHashService, storageProviderResolver, storageService, recipeStoreService,
                 recipeParser, recipeMapper, htmlExtractor, compressor, transformer, validationService, geminiRestTransformer);
 
         try {

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/StorageProviderResolverTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/StorageProviderResolverTest.java
@@ -1,0 +1,38 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.cookbook.dto.StorageType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StorageProviderResolverTest {
+
+    @Test
+    void resolve_returnsProviderForType() {
+        StorageProvider google = mock(StorageProvider.class);
+        StorageProvider dropbox = mock(StorageProvider.class);
+        when(google.type()).thenReturn(StorageType.GOOGLE_DRIVE);
+        when(dropbox.type()).thenReturn(StorageType.DROPBOX);
+
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(google, dropbox));
+
+        assertThat(resolver.resolve(StorageType.GOOGLE_DRIVE)).isSameAs(google);
+        assertThat(resolver.resolve(StorageType.DROPBOX)).isSameAs(dropbox);
+    }
+
+    @Test
+    void resolve_unknownType_throws() {
+        StorageProvider google = mock(StorageProvider.class);
+        when(google.type()).thenReturn(StorageType.GOOGLE_DRIVE);
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(google));
+
+        assertThatThrownBy(() -> resolver.resolve(StorageType.ONE_DRIVE))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ONE_DRIVE");
+    }
+}

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/StorageServiceTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/StorageServiceTest.java
@@ -67,11 +67,17 @@ class StorageServiceTest {
     private StorageService storageService;
     @Mock
     private net.shamansoft.cookbook.client.GoogleDrive googleDrive;
+    @Mock
+    private net.shamansoft.cookbook.client.DropboxAuthClient dropboxAuthClient;
+    @Mock
+    private DropboxStorageProvider dropboxStorageProvider;
 
     @BeforeEach
     void setUp() {
-        storageService = new StorageService(firestore, tokenEncryptionService, googleAuthClient, googleDrive);
+        storageService = new StorageService(firestore, tokenEncryptionService, googleAuthClient, googleDrive,
+                dropboxAuthClient, dropboxStorageProvider);
         ReflectionTestUtils.setField(storageService, "defaultFolderName", "kukbuk");
+        ReflectionTestUtils.setField(storageService, "defaultDropboxFolderName", "kukbuk");
         when(firestore.collection("users")).thenReturn(usersCollection);
         when(usersCollection.document(USER_ID)).thenReturn(userDocument);
     }
@@ -117,6 +123,80 @@ class StorageServiceTest {
         assertThat(storage.get("refreshToken")).isEqualTo(ENCRYPTED_REFRESH);
         assertThat(storage.get("folderId")).isEqualTo(FOLDER_ID);
         assertThat(storage.get("folderName")).isEqualTo(FOLDER_NAME);
+    }
+
+    // ====================== Dropbox Tests ======================
+
+    @Test
+    @DisplayName("Should connect Dropbox and persist type=dropbox with app-root folder")
+    void shouldConnectDropbox() throws Exception {
+        net.shamansoft.cookbook.client.DropboxAuthClient.TokenResponse tokens =
+                new net.shamansoft.cookbook.client.DropboxAuthClient.TokenResponse(ACCESS_TOKEN, REFRESH_TOKEN, 14400L);
+        when(dropboxAuthClient.exchangeAuthorizationCode("dbx-code", "sar://cb")).thenReturn(tokens);
+        when(dropboxStorageProvider.getOrCreateFolder(ACCESS_TOKEN, "kukbuk"))
+                .thenReturn(new StorageProvider.FolderRef("", "kukbuk"));
+        when(tokenEncryptionService.encrypt(ACCESS_TOKEN)).thenReturn(ENCRYPTED_ACCESS);
+        when(tokenEncryptionService.encrypt(REFRESH_TOKEN)).thenReturn(ENCRYPTED_REFRESH);
+        when(userDocument.update(eq("storage"), any(Map.class))).thenReturn(writeFuture);
+        when(writeFuture.get()).thenReturn(mock(WriteResult.class));
+
+        StorageService.FolderInfo result = storageService.connectDropbox(USER_ID, "dbx-code", "sar://cb", null);
+
+        assertThat(result.folderId()).isEqualTo("");
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(userDocument).update(eq("storage"), captor.capture());
+        assertThat(captor.getValue().get("type")).isEqualTo("dropbox");
+        assertThat(captor.getValue().get("accessToken")).isEqualTo(ENCRYPTED_ACCESS);
+    }
+
+    @Test
+    @DisplayName("Should refresh Dropbox token via DropboxAuthClient")
+    void shouldRefreshDropboxToken() throws Exception {
+        long past = System.currentTimeMillis() / 1000 - 3600;
+        Timestamp expiredAt = Timestamp.ofTimeSecondsAndNanos(past, 0);
+        StorageEntity entity = StorageEntity.builder()
+                .type("dropbox").connected(true)
+                .accessToken(ENCRYPTED_ACCESS).refreshToken(ENCRYPTED_REFRESH)
+                .expiresAt(expiredAt).connectedAt(Timestamp.now()).folderId("").build();
+
+        when(userDocument.get()).thenReturn(documentFuture);
+        when(documentFuture.get()).thenReturn(documentSnapshot);
+        when(documentSnapshot.exists()).thenReturn(true);
+        when(documentSnapshot.get("storage")).thenReturn(entity.toMap());
+        when(dropboxAuthClient.isTokenExpired(expiredAt)).thenReturn(true);
+        when(tokenEncryptionService.decrypt(ENCRYPTED_REFRESH)).thenReturn(REFRESH_TOKEN);
+
+        Timestamp newExpiry = Timestamp.ofTimeSecondsAndNanos(System.currentTimeMillis() / 1000 + 14400, 0);
+        when(dropboxAuthClient.refreshAccessToken(REFRESH_TOKEN))
+                .thenReturn(new net.shamansoft.cookbook.client.DropboxAuthClient.RefreshTokenResponse("dbx-new", newExpiry));
+        when(tokenEncryptionService.encrypt("dbx-new")).thenReturn("enc-new");
+        when(userDocument.update(anyString(), any(), anyString(), any())).thenReturn(writeFuture);
+        when(writeFuture.get()).thenReturn(mock(WriteResult.class));
+
+        StorageInfo result = storageService.getStorageInfo(USER_ID);
+
+        assertThat(result.accessToken()).isEqualTo("dbx-new");
+        assertThat(result.type()).isEqualTo(StorageType.DROPBOX);
+        verify(dropboxAuthClient).refreshAccessToken(REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("Should revoke Dropbox token before clearing storage on disconnect")
+    void shouldRevokeDropboxTokenOnDisconnect() throws Exception {
+        StorageEntity entity = StorageEntity.builder()
+                .type("dropbox").connected(true)
+                .accessToken(ENCRYPTED_ACCESS).folderId("").build();
+        when(userDocument.get()).thenReturn(documentFuture);
+        when(documentFuture.get()).thenReturn(documentSnapshot);
+        when(documentSnapshot.get("storage")).thenReturn(entity.toMap());
+        when(tokenEncryptionService.decrypt(ENCRYPTED_ACCESS)).thenReturn(ACCESS_TOKEN);
+        when(userDocument.update("storage", null)).thenReturn(writeFuture);
+        when(writeFuture.get()).thenReturn(mock(WriteResult.class));
+
+        storageService.disconnectStorage(USER_ID);
+
+        verify(dropboxAuthClient).revokeToken(ACCESS_TOKEN);
+        verify(userDocument).update("storage", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds **Dropbox** as a second recipe-storage backend behind a new provider abstraction. A user can connect Dropbox and have all existing recipe/media endpoints read and write it, with **zero behavior change for Google Drive users**.

Implemented per plan `docs/superpowers/plans/2026-07-19-dropbox-storage-backend.md` (research in the top-level `research/` dir: `storage_options.md`, `dropbox-backend-contract.md`, `dropbox-integration-and-legal.md`).

## What changed

**New provider abstraction**
- `StorageProvider` interface + `StorageProviderResolver` (selects impl by the user's stored `storage.type`).
- `GoogleDriveStorageProvider` (wraps the existing `DriveService`) and `DropboxStorageProvider` (App-folder path semantics, `id:`-addressed files).
- `RecipeService` / `RecipeMediaProxyService` now route through the resolver instead of the concrete Google bean. **Recipe/media HTTP endpoints are unchanged.**

**Dropbox clients**
- `DropboxAuthClient` — OAuth2 authorization-code exchange, refresh, and server-side token revoke (`/2/auth/token/revoke`).
- `DropboxClient` — file API: `create_folder_v2` (409 = already-exists), `upload`, `download`, `list_folder`(+`/continue`, cursor↔pageToken), `get_metadata`.

**Wiring & persistence**
- `StorageService`: `connectDropbox`, provider-aware token refresh & expiry check, revoke-on-disconnect.
- `StorageEntity.toMap()` now persists the actual `type` (no longer hardcodes `googleDrive`).

**HTTP surface** (existing `/v1/storage/google-drive/*` untouched)
- `POST /v1/storage/dropbox/connect`
- `GET /v1/storage/status` (provider-neutral)
- `DELETE /v1/storage/disconnect` (provider-neutral)

## Design notes
- **App-folder access** (not Full Dropbox): least-privilege; every Dropbox path is relative to the app folder, so `folderId=""` is the app-folder root.
- Tokens stay encrypted at rest (KMS `TokenEncryptionService`); auto-refresh is now provider-aware.
- Single storage per user; connecting Dropbox replaces any existing connection (no cross-provider migration).

## Deviations from the plan (intentional, called out)
- `GoogleDriveStorageProvider` depends on the **`DriveService` interface**, not the concrete `GoogleDriveService`. This keeps two `@SpringBootTest` tests the plan hadn't listed (`RecipeControllerSBTest`, `EntitlementEndToEndTest`, both `@MockitoBean DriveService`) passing without edits.
- `StorageServiceTest` sets `defaultDropboxFolderName` via reflection (needed by the connect test; the plan omitted it).

## Testing
- `./gradlew :cookbook:test` — full unit suite ✅
- `./gradlew :cookbook:intTest` — full integration suite (Testcontainers/WireMock) ✅
- `./gradlew :cookbook:checkCoverage` — 40% gate ✅
- `./gradlew :cookbook:build` ✅

New unit tests cover the auth client, file client, both providers, the resolver, `StorageEntity`, connect/refresh/revoke in `StorageService`, and the three new controller endpoints.

## Follow-ups (not in this PR)
- Provision `cookbook.dropbox.app-secret` in Secret Manager (`sar-infra`), env `COOKBOOK_DROPBOX_APP_SECRET`; set `COOKBOOK_DROPBOX_APP_KEY`. See `research/dropbox-integration-and-legal.md` (Dropbox app registration, App-folder scope, production review, privacy-policy amendment).
- Native-image reflection: no new `reflect-config.json` entries anticipated (same `Map`/`ParameterizedTypeReference` pattern as `GoogleDrive`); confirm on first Cloud Run deploy.
- KMP client work is planned separately (`sar-kmp` plan) against the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
