### PR TITLE
chore: bump Gemini model to gemini-3.5-flash-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ native image compilation, and deployment to Google Cloud Run. Current version: *
 - **Java 21** with Spring Boot 3.4.2 for the REST API
 - **Gradle 9.2.0** for building and dependency management
 - **GraalVM Native Image** for fast startup and low memory footprint
-- **Gemini AI** (gemini-2.5-flash-lite) for intelligent recipe extraction
+- **Gemini AI** (gemini-3.5-flash-lite) for intelligent recipe extraction
 - **Docker** for containerization
 - **GitHub Actions** for CI/CD automation (Java 25 for builds)
 - **OpenTofu/Terraform** for infrastructure as code

--- a/extractor/README.md
+++ b/extractor/README.md
@@ -101,7 +101,7 @@ cookbook:
   gemini:
     api-key: "YOUR_GEMINI_API_KEY"
     base-url: "https://generativelanguage.googleapis.com/v1beta"
-    model: "gemini-2.5-flash-lite"
+    model: "gemini-3.5-flash-lite"
     temperature: 0.1
     top-p: 0.8
     max-output-tokens: 4096

--- a/extractor/src/intTest/java/net/shamansoft/cookbook/AddRecipeIT.java
+++ b/extractor/src/intTest/java/net/shamansoft/cookbook/AddRecipeIT.java
@@ -167,7 +167,7 @@ class AddRecipeIT {
 
     private void setupGeminiMock() {
         // Mock Gemini API response for recipe transformation
-        stubFor(post(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*"))
+        stubFor(post(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -357,11 +357,11 @@ class AddRecipeIT {
                         true);
 
         // Verify Gemini was called for transformation
-        verify(postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*")));
+        verify(postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*")));
 
         // Verify request body sent to Gemini contains the extraction instruction and
         // page title
-        verify(postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*"))
+        verify(postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*"))
                 .withRequestBody(containing("You are a strict Recipe Data Extractor"))
                 .withRequestBody(containing("Chocolate Chip Cookies")));
 
@@ -412,7 +412,7 @@ class AddRecipeIT {
         assertThat(response.getBody().get("error")).asString().isEqualTo("Storage Not Connected");
 
         // Verify that Gemini and Drive were NOT called
-        verify(0, postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*")));
+        verify(0, postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*")));
         verify(0, getRequestedFor(urlPathEqualTo("/files")));
     }
 
@@ -467,7 +467,7 @@ class AddRecipeIT {
         assertThat(response.getBody().url()).isEqualTo(testUrl);
 
         // Verify Gemini was NOT called (cache hit)
-        verify(0, postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*")));
+        verify(0, postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*")));
 
         // Verify Drive was still called to upload
         verify(postRequestedFor(urlPathEqualTo("/files")));
@@ -480,7 +480,7 @@ class AddRecipeIT {
         setupStorageInfoInFirestore("test-user-123", "valid-drive-token");
 
         // AND: Gemini returns isRecipe=false
-        stubFor(post(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*"))
+        stubFor(post(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -515,7 +515,7 @@ class AddRecipeIT {
         assertThat(response.getBody().driveFileUrl()).isNull();
 
         // Verify Gemini was called but Drive was NOT
-        verify(postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*")));
+        verify(postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*")));
         verify(0, postRequestedFor(urlPathEqualTo("/files")));
     }
 
@@ -592,7 +592,7 @@ class AddRecipeIT {
 
         // Verify that HTML sent to Gemini was preprocessed (smaller than original)
         // We can check the request body size sent to Gemini
-        verify(postRequestedFor(urlPathMatching("/models/gemini-2.5-flash-lite:generateContent.*")));
+        verify(postRequestedFor(urlPathMatching("/models/gemini-3.5-flash-lite:generateContent.*")));
 
         // The preprocessed HTML should not contain scripts, styles, nav, footer, ads
         // This is validated by the fact that the request succeeded and was processed

--- a/extractor/src/main/java/net/shamansoft/cookbook/debug/DebugController.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/debug/DebugController.java
@@ -217,7 +217,7 @@ public class DebugController {
                 if (request.isVerbose()) {
                     metadataBuilder
                             .transformationTimeMs(transformTime)
-                            .geminiModel("gemini-2.5-flash-lite"); // TODO: Get from config
+                            .geminiModel("gemini-3.5-flash-lite"); // TODO: Get from config
                 }
 
                 // Dump raw LLM response if flag enabled

--- a/extractor/src/main/resources/application.yaml
+++ b/extractor/src/main/resources/application.yaml
@@ -188,7 +188,7 @@ cookbook:
     # Used by: GeminiRestTransformer.java:45 (@Value("${cookbook.gemini.model}"))
     # Default: gemini-2.5-flash
     # Options: gemini-2.5-flash, gemini-2.0-flash, gemini-1.5-pro
-    model: "gemini-2.5-flash-lite"
+    model: "gemini-3.5-flash-lite"
 
     # Temperature parameter for Gemini model (0.0 to 1.0)
     # Used by: RequestBuilder.java:31 (@Value("${cookbook.gemini.temperature}"))


### PR DESCRIPTION
## Summary
- Update the Gemini model used for recipe extraction from `gemini-2.5-flash-lite` to `gemini-3.5-flash-lite` in `application.yaml`
- Update matching references in READMEs, the debug controller placeholder, and WireMock integration test stubs

## Test plan
- [x] `./gradlew :cookbook:test --tests "*GeminiClientTest*" --tests "*RecipeResponseTest*" --tests "*DebugController*"` passes
- [ ] `./gradlew :cookbook:intTest` (WireMock stubs updated to match new model path; not run locally — requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)