### PR TITLE
fix: preserve UTF-8 encoding when uploading new Drive files

### DIFF
--- a/extractor/src/main/java/net/shamansoft/cookbook/client/GoogleDrive.java
+++ b/extractor/src/main/java/net/shamansoft/cookbook/client/GoogleDrive.java
@@ -193,7 +193,7 @@ public class GoogleDrive {
                             .queryParam("fields", "id")
                             .build())
                     .header("Authorization", "Bearer " + authToken)
-                    .contentType(org.springframework.http.MediaType.parseMediaType("application/x-yaml"))
+                    .contentType(new org.springframework.http.MediaType("application", "x-yaml", java.nio.charset.StandardCharsets.UTF_8))
                     .body(content)
                     .retrieve()
                     .body(new ParameterizedTypeReference<Map<String, Object>>() {

--- a/extractor/src/test/java/net/shamansoft/cookbook/client/GoogleDriveTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/client/GoogleDriveTest.java
@@ -375,7 +375,8 @@ class GoogleDriveTest {
         when(mockUploadClient.patch()).thenReturn(mockUploadBodySpec);
         when(mockUploadBodySpec.uri(any(Function.class))).thenReturn(mockUploadReqBodySpec);
         when(mockUploadReqBodySpec.header(eq("Authorization"), anyString())).thenReturn(mockUploadReqBodySpec);
-        when(mockUploadReqBodySpec.contentType(any(MediaType.class))).thenReturn(mockUploadReqBodySpec);
+        when(mockUploadReqBodySpec.contentType(eq(new MediaType("application", "x-yaml", java.nio.charset.StandardCharsets.UTF_8))))
+                .thenReturn(mockUploadReqBodySpec);
         doReturn(mockUploadReqBodySpec).when(mockUploadReqBodySpec).body(any(String.class));
         when(mockUploadReqBodySpec.retrieve()).thenReturn(mockUploadResponseSpec);
 

--- a/extractor/src/test/java/net/shamansoft/cookbook/service/EncodingReproductionTest.java
+++ b/extractor/src/test/java/net/shamansoft/cookbook/service/EncodingReproductionTest.java
@@ -1,0 +1,39 @@
+package net.shamansoft.cookbook.service;
+
+import net.shamansoft.recipe.model.Recipe;
+import net.shamansoft.recipe.model.RecipeMetadata;
+import net.shamansoft.recipe.parser.RecipeSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EncodingReproductionTest {
+
+    @Test
+    void shouldPreserveSmartQuotesInYaml() throws Exception {
+        RecipeSerializer serializer = new RecipeSerializer();
+
+        Recipe recipe = new Recipe(
+                true,
+                "1.0.0",
+                "1.0.0",
+                new RecipeMetadata("Test Recipe", "src", null, "en", null, null, null, null, null, null, null, null,
+                        null),
+                "They won’t rise if you don’t dimple them.",
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                "",
+                null);
+
+        String yaml = serializer.serialize(recipe);
+        System.out.println("Generated YAML:\n" + yaml);
+
+        assertThat(yaml).contains("won’t");
+        assertThat(yaml).contains("don’t");
+        assertThat(yaml).doesNotContain("won?t");
+    }
+}


### PR DESCRIPTION
## Summary
- `GoogleDrive.createFile()` uploaded new recipe YAML with `Content-Type: application/x-yaml` and no charset. Spring's `StringHttpMessageConverter` defaults to ISO-8859-1 when no charset is specified, so non-ASCII characters (e.g. `ñ` in "jalapeño") were written to Drive as ISO-8859-1 bytes.
- That single-byte encoding is not valid standalone UTF-8, so when the content is later read back via `downloadFileAsString` (which explicitly decodes as UTF-8), it collapses to a `U+FFFD` replacement character - rendered by the app as `?`.
- `updateFile()` (editing an existing recipe) already set the charset explicitly; `createFile()` now matches it. Verified by reproducing the exact byte corruption (`jalapeño` -> Latin-1 bytes -> strict UTF-8 decode -> `jalape�o`).
- Tightened `GoogleDriveTest.testCreateFileSuccess` to assert the exact `Content-Type` (including charset) used on upload, so a regression would fail the test. Confirmed it fails without the fix and passes with it.
- Also carries over `EncodingReproductionTest` (recipe-sdk `RecipeSerializer` round-trip for smart quotes) from an earlier, inconclusive investigation into the same user-reported symptom - it doesn't cover the actual bug (in-memory serialization was never the problem) but is still valid extra coverage.

Existing recipes already saved with corrupted bytes on Drive will need to be re-saved (which goes through the already-correct `updateFile()` path) to repair - this PR only fixes new writes going forward.

## Test plan
- [x] `./gradlew :cookbook:test` - full suite passes
- [x] Manually reverted the fix and confirmed `testCreateFileSuccess` fails (NPE from mismatched content-type stub), then restored and confirmed it passes
- [x] Reproduced the ISO-8859-1/UTF-8 byte corruption standalone to confirm root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)